### PR TITLE
Add `null_sink_mt`

### DIFF
--- a/logger.hpp.in
+++ b/logger.hpp.in
@@ -414,6 +414,15 @@ class ostream_sink_mt : public sink {
   ostream_sink_mt(std::ostream& stream, bool force_flush = false);
 };
 
+/**
+ * @brief A sink that writes nothing.
+ *
+ * See spdlog::sinks::null_sink_mt for more information.
+ */
+class null_sink_mt : public sink {
+ public:
+  null_sink_mt();
+};
 
 /**
  * @brief Returns the default log filename for the global logger.

--- a/logger_impl.hpp.in
+++ b/logger_impl.hpp.in
@@ -166,6 +166,9 @@ basic_file_sink_mt::basic_file_sink_mt(std::string const& filename, bool truncat
 ostream_sink_mt::ostream_sink_mt(std::ostream& stream, bool force_flush)
   : sink{std::make_unique<detail::sink_impl>(std::make_shared<spdlog::sinks::ostream_sink_mt>(stream, force_flush))} {}
 
+null_sink_mt::null_sink_mt()
+  : sink{std::make_unique<detail::sink_impl>(std::make_shared<spdlog::sinks::null_sink_mt>())} {}
+
 // Logger methods
 logger::logger(std::string name, std::string filename)
   : impl{std::make_unique<detail::logger_impl>(name)}, sinks_{*this} {

--- a/logger_impl.hpp.in
+++ b/logger_impl.hpp.in
@@ -33,6 +33,7 @@
 #pragma GCC diagnostic ignored "-Wattributes"
 
 #include <spdlog/sinks/basic_file_sink.h>
+#include <spdlog/sinks/null_sink.h>
 #include <spdlog/sinks/ostream_sink.h>
 #include <spdlog/spdlog.h>
 #pragma GCC diagnostic pop


### PR DESCRIPTION
This adds `null_sink_mt`, the equivalent to `spdlog::null_sink_mt` to allow disabling logging upon needed.