### PR TITLE
Fix the interface include directory on the logger target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,7 +142,7 @@ function(rapids_make_logger logger_namespace)
   target_include_directories(
     ${_RAPIDS_LOGGER_TARGET}
     INTERFACE "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_INSTALL_INCLUDEDIR}>"
-              "$<INSTALL_INTERFACE:${_RAPIDS_LOGGER_HEADER_DIR}>")
+              "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
   target_compile_features(${_RAPIDS_LOGGER_TARGET} INTERFACE cxx_std_17)
 
   # Create an interface target that will trigger compilation of the logger implementation in any


### PR DESCRIPTION
The install interface directory should just be `include/`, not the path to where the file is installed. In the default case the former will be one level deeper `include/<project_name>`, and in the general case will be `include/${LOGGER_HEADER_DIR}` which is not what we want since consumers will always specify include paths relative to the root e.g. `#include <${project_name}/logger.hpp>` or similar.