### PR TITLE
Add stderr sink and use as default

### DIFF
--- a/logger.hpp.in
+++ b/logger.hpp.in
@@ -428,7 +428,7 @@ class null_sink_mt : public sink {
  *
  * See spdlog::sinks::stderr_sink_mt for more information.
  */
-class stderr_sink_mt : public stderr_sink_mt {
+class stderr_sink_mt : public sink {
  public:
   stderr_sink_mt();
 };

--- a/logger.hpp.in
+++ b/logger.hpp.in
@@ -424,6 +424,16 @@ class null_sink_mt : public sink {
   null_sink_mt();
 };
 
+/**
+ * @brief A sink that writes to stderr.
+ *
+ * See spdlog::sinks::stderr_sink_mt for more information.
+ */
+class stderr_sink_mt : public stderr_sink_mt {
+ public:
+  stderr_sink_mt();
+};
+
 typedef void (*log_callback_t)(int lvl, const char* msg);
 typedef void (*flush_callback_t)();
 

--- a/logger.hpp.in
+++ b/logger.hpp.in
@@ -455,7 +455,7 @@ public:
 inline sink_ptr default_sink()
 {
   auto* filename = std::getenv("@_RAPIDS_LOGGER_MACRO_PREFIX@_DEBUG_LOG_FILE");
-  return (filename == nullptr) ? std::make_shared<stderr_sink_mt>() : std::make_shared<basic_file_sink_mt>(filename, true);
+  return (filename == nullptr) ? static_cast<sink_ptr>(std::make_shared<stderr_sink_mt>()) : static_cast<sink_ptr>(std::make_shared<basic_file_sink_mt>(filename, true));
 }
 
 /**

--- a/logger.hpp.in
+++ b/logger.hpp.in
@@ -270,7 +270,6 @@ class logger {
     log(level_enum::critical, format, std::forward<Args>(args)...);
   }
 
-  // Everything below here is conditionally compiled based on whether logging is supported.
   /**
    * @brief Construct a new logger object
    *
@@ -453,12 +452,10 @@ public:
  *
  * @return std::string The default log file name.
  */
-inline std::string default_log_filename()
+inline sink_ptr default_sink()
 {
   auto* filename = std::getenv("@_RAPIDS_LOGGER_MACRO_PREFIX@_DEBUG_LOG_FILE");
-  // TODO: Do we prefer rmm's default (a file rmm_log.txt) or cudf's default (a
-  // stderr sink)? I think the latter is better.
-  return (filename == nullptr) ? std::string{"@_RAPIDS_LOGGER_NAMESPACE@_log.txt"} : std::string{filename};
+  return (filename == nullptr) ? std::make_shared<stderr_sink_mt>() : std::make_shared<basic_file_sink_mt>(filename, true);
 }
 
 /**
@@ -477,7 +474,7 @@ inline logger& default_logger()
 {
   static logger logger_ = [] {
     logger logger_ {
-      "@_RAPIDS_LOGGER_MACRO_PREFIX@", default_log_filename()
+      "@_RAPIDS_LOGGER_MACRO_PREFIX@", {default_sink()}
     };
 #if @_RAPIDS_LOGGER_MACRO_PREFIX@_LOG_ACTIVE_LEVEL <= @_RAPIDS_LOGGER_MACRO_PREFIX@_LOG_LEVEL_INFO
 #ifdef CUDA_API_PER_THREAD_DEFAULT_STREAM

--- a/logger_impl.hpp.in
+++ b/logger_impl.hpp.in
@@ -32,12 +32,13 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wattributes"
 
+#include <spdlog/details/log_msg.h>
+#include <spdlog/sinks/base_sink.h>
 #include <spdlog/sinks/basic_file_sink.h>
 #include <spdlog/sinks/null_sink.h>
 #include <spdlog/sinks/ostream_sink.h>
+#include <spdlog/sinks/stdout_sinks.h>
 #include <spdlog/spdlog.h>
-#include <spdlog/details/log_msg.h>
-#include <spdlog/sinks/base_sink.h>
 #pragma GCC diagnostic pop
 
 #include <iostream>
@@ -210,6 +211,9 @@ ostream_sink_mt::ostream_sink_mt(std::ostream& stream, bool force_flush)
 
 null_sink_mt::null_sink_mt()
   : sink{std::make_unique<detail::sink_impl>(std::make_shared<spdlog::sinks::null_sink_mt>())} {}
+
+stderr_sink_mt::stderr_sink_mt()
+  : sink{std::make_unique<detail::sink_impl>(std::make_shared<spdlog::sinks::stderr_sink_mt>())} {}
 
 callback_sink_mt::callback_sink_mt(const log_callback_t &callback, const flush_callback_t &flush)
   : sink{std::make_unique<detail::sink_impl>(std::make_shared<detail::callback_sink<std::mutex>>(callback, flush))} {}


### PR DESCRIPTION
This PR changes the default behavior of the logger to send output to stderr instead of to a file. That behavior matches the prior default behavior of 3/4 repositories using rapids-logger (rmm was the exception) and also adheres more closely to user expectations that have been communicated to me.