### PR TITLE
Add default level.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,7 @@ Example on how to use :cmake:command:`rapids_make_logger`.
   # associate it with the export set "rapids-exports".
   rapids_make_logger(rapids
     EXPORT_SET rapids-exports
-    LOGGER_DEFAULT_LEVEL INFO
+    LOGGER_DEFAULT_LEVEL WARN
   )
 
 #]=======================================================================]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,11 +41,12 @@ Generate a logger implementation customized for the specified namespace.
 
 .. code-block:: cmake
 
-  rapids_make_logger(<logger_namespace> <logger_default_level>
+  rapids_make_logger(<logger_namespace>
     [EXPORT_SET <export-set-name>]
     [LOGGER_TARGET <logger-target-name>]
     [LOGGER_HEADER_DIR <header-dir>]
     [LOGGER_MACRO_PREFIX <macro-prefix>]
+    [LOGGER_DEFAULT_LEVEL <logger-default-level>]
     [CMAKE_ALIAS_NAMESPACE <alias-namespace>]
   )
 
@@ -56,9 +57,6 @@ The logger implementation lives in a separate header file that is not included i
 
 ``logger_namespace``
   The namespace for which to generate the logger implementation.
-
-``logger_default_level``
-  The default level used by the logger at runtime.
 
 ``EXPORT_SET``
   The name of the export set to which the logger target should be added. If not specified, the logger target is not added to any export set.
@@ -71,6 +69,9 @@ The logger implementation lives in a separate header file that is not included i
 
 ``LOGGER_MACRO_PREFIX``
   The prefix to use for the logger macros. If not specified, the macro prefix is the uppercase version of the logger namespace.
+
+``LOGGER_DEFAULT_LEVEL``
+  The default level used by the logger at runtime.
 
 ``CMAKE_ALIAS_NAMESPACE``
   The namespace to use for the CMake alias target. If not specified, the alias namespace is the same as the logger namespace.
@@ -91,23 +92,23 @@ Example on how to use :cmake:command:`rapids_make_logger`.
 
   # Generate a logger for the namespace "rapids" with default level INFO and
   # associate it with the export set "rapids-exports".
-  rapids_make_logger(rapids INFO
+  rapids_make_logger(rapids
     EXPORT_SET rapids-exports
+    LOGGER_DEFAULT_LEVEL INFO
   )
 
 #]=======================================================================]
-function(rapids_make_logger logger_namespace logger_default_level)
+function(rapids_make_logger logger_namespace)
   list(APPEND CMAKE_MESSAGE_CONTEXT "rapids_make_logger")
 
   set(_rapids_options)
-  set(_rapids_one_value EXPORT_SET LOGGER_TARGET LOGGER_HEADER_DIR LOGGER_MACRO_PREFIX)
+  set(_rapids_one_value EXPORT_SET LOGGER_TARGET LOGGER_HEADER_DIR LOGGER_MACRO_PREFIX LOGGER_DEFAULT_LEVEL)
   set(_rapids_multi_value)
   cmake_parse_arguments(_RAPIDS "${_rapids_options}" "${_rapids_one_value}"
                         "${_rapids_multi_value}" ${ARGN})
 
   # Most arguments are optional and can be inferred from the namespace by default.
   set(_RAPIDS_LOGGER_NAMESPACE ${logger_namespace})
-  set(_RAPIDS_LOGGER_DEFAULT_LEVEL ${logger_default_level})
   if(NOT _RAPIDS_LOGGER_TARGET)
     set(_RAPIDS_LOGGER_TARGET "${logger_namespace}_logger")
   endif()
@@ -116,6 +117,9 @@ function(rapids_make_logger logger_namespace logger_default_level)
   endif()
   if(NOT _RAPIDS_LOGGER_MACRO_PREFIX)
     string(TOUPPER ${logger_namespace} _RAPIDS_LOGGER_MACRO_PREFIX)
+  endif()
+  if(NOT _RAPIDS_LOGGER_DEFAULT_LEVEL)
+    set(_RAPIDS_LOGGER_DEFAULT_LEVEL "INFO")
   endif()
   if(NOT _RAPIDS_CMAKE_NAMESPACE_ALIAS)
     set(_RAPIDS_CMAKE_NAMESPACE_ALIAS ${logger_namespace})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,7 @@ The logger implementation lives in a separate header file that is not included i
   The prefix to use for the logger macros. If not specified, the macro prefix is the uppercase version of the logger namespace.
 
 ``LOGGER_DEFAULT_LEVEL``
-  The default level used by the logger at runtime.
+  The default level used by the logger at runtime. If not specified, defaults to "INFO".
 
 ``CMAKE_ALIAS_NAMESPACE``
   The namespace to use for the CMake alias target. If not specified, the alias namespace is the same as the logger namespace.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ Generate a logger implementation customized for the specified namespace.
 
 .. code-block:: cmake
 
-  rapids_make_logger(<logger_namespace>
+  rapids_make_logger(<logger_namespace> <logger_default_level>
     [EXPORT_SET <export-set-name>]
     [LOGGER_TARGET <logger-target-name>]
     [LOGGER_HEADER_DIR <header-dir>]
@@ -56,6 +56,9 @@ The logger implementation lives in a separate header file that is not included i
 
 ``logger_namespace``
   The namespace for which to generate the logger implementation.
+
+``logger_default_level``
+  The default level used by the logger at runtime.
 
 ``EXPORT_SET``
   The name of the export set to which the logger target should be added. If not specified, the logger target is not added to any export set.
@@ -86,18 +89,14 @@ Example on how to use :cmake:command:`rapids_make_logger`.
 
 .. code-block:: cmake
 
-  # Generate a logger for the namespace "rapids" and associate it with the
-  # export set "rapids-exports".
-  rapids_make_logger(rapids
+  # Generate a logger for the namespace "rapids" with default level INFO and
+  # associate it with the export set "rapids-exports".
+  rapids_make_logger(rapids INFO
     EXPORT_SET rapids-exports
   )
 
-  # Generate a logger for the namespace "rmm" that does not support logging.
-  rapids_make_logger(rapids)
-
-
 #]=======================================================================]
-function(rapids_make_logger logger_namespace)
+function(rapids_make_logger logger_namespace logger_default_level)
   list(APPEND CMAKE_MESSAGE_CONTEXT "rapids_make_logger")
 
   set(_rapids_options)
@@ -108,6 +107,7 @@ function(rapids_make_logger logger_namespace)
 
   # Most arguments are optional and can be inferred from the namespace by default.
   set(_RAPIDS_LOGGER_NAMESPACE ${logger_namespace})
+  set(_RAPIDS_LOGGER_DEFAULT_LEVEL ${logger_default_level})
   if(NOT _RAPIDS_LOGGER_TARGET)
     set(_RAPIDS_LOGGER_TARGET "${logger_namespace}_logger")
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,7 +90,7 @@ Example on how to use :cmake:command:`rapids_make_logger`.
 
 .. code-block:: cmake
 
-  # Generate a logger for the namespace "rapids" with default level INFO and
+  # Generate a logger for the namespace "rapids" with default level WARN and
   # associate it with the export set "rapids-exports".
   rapids_make_logger(rapids
     EXPORT_SET rapids-exports

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ RAPIDS_LOG_DEBUG("Some message to be shown when the debug level is enabled");
 and control whether that message is shown by compiling the code with `RAPIDS_LOG_ACTIVE_LEVEL=RAPIDS_LOG_LEVEL_DEBUG`.
 Additionally, the default runtime logging level can be controlled at compile time through the `LOGGER_DEFAULT_LEVEL` argument of `rapids_make_logger`.
 This default runtime value allows for compiling with `INFO` level messages available, but only showing `WARN` or higher at runtime by default.
+Users can then opt in to more verbose logging at runtime using `default_logger().set_level(...)`.
 
 Each project is endowed with its own definition of levels, so different projects in the same environment may be safely configured independently of each other and of spdlog.
 Each project is also given a `default_logger` function that produces a global logger that may be used anywhere, but projects may also freely instantiate additional loggers as needed.

--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ This project has two primary goals:
 2. Ensure that custom logger implementations based on spdlog do not leak any spdlog (or fmt) symbols, allowing the safe coexistence of different projects in the same environment even if they use different versions of spdlog.
 
 `rapids-logger` is designed to be used via CMake.
-Its CMakeLists.txt defines a function `rapids_make_logger` that can be used to produce a project-specific logger class in a provided namespace.
+Its CMakeLists.txt defines a function `rapids_make_logger` that can be used to produce a project-specific logger class in a provided namespace with the given default logger level.
 The resulting logger exposes spdlog-like functionality via the [PImpl idiom](https://en.cppreference.com/w/cpp/language/pimpl) to avoid exposing spdlog symbols publicly.
 It uses CMake and template C++ files to generate a public header file to describe the user interface and an inline header that should be placed in a single TU by consumers to compile the implementation.
 To simplify usage, each invocation of the function produces two CMake targets, one representing the public header and one representing a trivial source file including the inline header.
 Projects using `rapids-logger` should make the first target part of their public link interface while the latter should be linked to privately so that it is compiled into the project's library without public exposure.
 
 To mirror spdlog, each generated logger also ships with a set of logging macros `<project-name>_LOG_<log-level>` that may be used to control logging at compile-time as well as runtime using a compile-time variable `<project-name>_LOG_ACTIVE_LEVEL`.
-For example, a project called "rapids" will be able to write code like this:
+For example, a project called "RAPIDS" will be able to write code like this:
 ```
 RAPIDS_LOG_WARN("Some message to be shown when the warning level is enabled");
 ```

--- a/README.md
+++ b/README.md
@@ -6,17 +6,22 @@ This project has two primary goals:
 2. Ensure that custom logger implementations based on spdlog do not leak any spdlog (or fmt) symbols, allowing the safe coexistence of different projects in the same environment even if they use different versions of spdlog.
 
 `rapids-logger` is designed to be used via CMake.
-Its CMakeLists.txt defines a function `rapids_make_logger` that can be used to produce a project-specific logger class in a provided namespace with the given default logger level.
+Its CMakeLists.txt defines a function `rapids_make_logger` that can be used to produce a project-specific logger class in a provided namespace.
 The resulting logger exposes spdlog-like functionality via the [PImpl idiom](https://en.cppreference.com/w/cpp/language/pimpl) to avoid exposing spdlog symbols publicly.
 It uses CMake and template C++ files to generate a public header file to describe the user interface and an inline header that should be placed in a single TU by consumers to compile the implementation.
 To simplify usage, each invocation of the function produces two CMake targets, one representing the public header and one representing a trivial source file including the inline header.
 Projects using `rapids-logger` should make the first target part of their public link interface while the latter should be linked to privately so that it is compiled into the project's library without public exposure.
 
-To mirror spdlog, each generated logger also ships with a set of logging macros `<project-name>_LOG_<log-level>` that may be used to control logging at compile-time as well as runtime using a compile-time variable `<project-name>_LOG_ACTIVE_LEVEL`.
+Logging levels are controlled both at compile-time and at runtime.
+To mirror spdlog, each generated logger ships with a set of logging macros `<project-name>_LOG_<log-level>`.
+These macros are compiled based on the value of the compile-time variable `<project-name>_LOG_ACTIVE_LEVEL`.
 For example, a project called "RAPIDS" will be able to write code like this:
 ```
-RAPIDS_LOG_WARN("Some message to be shown when the warning level is enabled");
+RAPIDS_LOG_DEBUG("Some message to be shown when the debug level is enabled");
 ```
-and control whether that warning is shown by compiling the code with `RAPIDS_LOG_ACTIVE_LEVEL=RAPIDS_LOG_LEVEL_WARN`.
+and control whether that message is shown by compiling the code with `RAPIDS_LOG_ACTIVE_LEVEL=RAPIDS_LOG_LEVEL_DEBUG`.
+Additionally, the default runtime logging level can be controlled at compile time through the `LOGGER_DEFAULT_LEVEL` argument of `rapids_make_logger`.
+This default runtime value allows for compiling with `INFO` level messages available, but only showing `WARN` or higher at runtime by default.
+
 Each project is endowed with its own definition of levels, so different projects in the same environment may be safely configured independently of each other and of spdlog.
 Each project is also given a `default_logger` function that produces a global logger that may be used anywhere, but projects may also freely instantiate additional loggers as needed.

--- a/logger.hpp.in
+++ b/logger.hpp.in
@@ -476,6 +476,7 @@ inline logger& default_logger()
     logger logger_ {
       "@_RAPIDS_LOGGER_MACRO_PREFIX@", {default_sink()}
     };
+    logger_.set_level(static_cast<level_enum>(@_RAPIDS_LOGGER_MACRO_PREFIX@_LOG_LEVEL_@_RAPIDS_LOGGER_DEFAULT_LEVEL@);
 #if @_RAPIDS_LOGGER_MACRO_PREFIX@_LOG_ACTIVE_LEVEL <= @_RAPIDS_LOGGER_MACRO_PREFIX@_LOG_LEVEL_DEBUG
 #ifdef CUDA_API_PER_THREAD_DEFAULT_STREAM
     logger_.debug("----- @_RAPIDS_LOGGER_MACRO_PREFIX@ LOG [PTDS ENABLED] -----");

--- a/logger.hpp.in
+++ b/logger.hpp.in
@@ -476,7 +476,7 @@ inline logger& default_logger()
     logger logger_ {
       "@_RAPIDS_LOGGER_MACRO_PREFIX@", {default_sink()}
     };
-    logger_.set_level(static_cast<level_enum>(@_RAPIDS_LOGGER_MACRO_PREFIX@_LOG_LEVEL_@_RAPIDS_LOGGER_DEFAULT_LEVEL@);
+    logger_.set_level(static_cast<level_enum>(@_RAPIDS_LOGGER_MACRO_PREFIX@_LOG_LEVEL_@_RAPIDS_LOGGER_DEFAULT_LEVEL@));
 #if @_RAPIDS_LOGGER_MACRO_PREFIX@_LOG_ACTIVE_LEVEL <= @_RAPIDS_LOGGER_MACRO_PREFIX@_LOG_LEVEL_DEBUG
 #ifdef CUDA_API_PER_THREAD_DEFAULT_STREAM
     logger_.debug("----- @_RAPIDS_LOGGER_MACRO_PREFIX@ LOG [PTDS ENABLED] -----");


### PR DESCRIPTION
We need to control the default runtime level for cuDF, so we can compile with INFO logs but only run with WARN logs.

This PR adds a way to control the default runtime level at compile time, separately from the compile-time level.
