### PR TITLE
Separate out log level macros

### DIFF
--- a/include/rapids_logger/log_levels.h
+++ b/include/rapids_logger/log_levels.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This is a C rather than C++ header to support usage of these macros in
+// C-only wrappers around C++ libraries that leverage rapids_logger.
+#pragma once
+
+// These values must be kept in sync with spdlog!
+#define RAPIDS_LOGGER_LOG_LEVEL_TRACE    0
+#define RAPIDS_LOGGER_LOG_LEVEL_DEBUG    1
+#define RAPIDS_LOGGER_LOG_LEVEL_INFO     2
+#define RAPIDS_LOGGER_LOG_LEVEL_WARN     3
+#define RAPIDS_LOGGER_LOG_LEVEL_ERROR    4
+#define RAPIDS_LOGGER_LOG_LEVEL_CRITICAL 5
+#define RAPIDS_LOGGER_LOG_LEVEL_OFF      6

--- a/include/rapids_logger/logger.hpp
+++ b/include/rapids_logger/logger.hpp
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include "log_levels.h"
+
 #include <memory>
 #include <ostream>
 #include <string>
@@ -32,13 +34,13 @@ namespace rapids_logger {
  * These levels correspond to the levels defined by spdlog.
  */
 enum class RAPIDS_LOGGER_EXPORT level_enum : int32_t {
-  trace    = 0,
-  debug    = 1,
-  info     = 2,
-  warn     = 3,
-  error    = 4,
-  critical = 5,
-  off      = 6,
+  trace    = RAPIDS_LOGGER_LOG_LEVEL_TRACE,
+  debug    = RAPIDS_LOGGER_LOG_LEVEL_DEBUG,
+  info     = RAPIDS_LOGGER_LOG_LEVEL_INFO,
+  warn     = RAPIDS_LOGGER_LOG_LEVEL_WARN,
+  error    = RAPIDS_LOGGER_LOG_LEVEL_ERROR,
+  critical = RAPIDS_LOGGER_LOG_LEVEL_CRITICAL,
+  off      = RAPIDS_LOGGER_LOG_LEVEL_OFF,
   n_levels
 };
 


### PR DESCRIPTION
The log levels are universal for all projects and are also usable in pure C code, so they can live in a standalone, nontemplated header.