### PR TITLE
Add static library build to CI suite

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -74,4 +74,4 @@ jobs:
       sha: ${{ inputs.sha }}
       date: ${{ inputs.date }}
       container_image: "rapidsai/ci-wheel:latest"
-      run_script: "ci/configure_cpp_static.sh"
+      run_script: "ci/build_static.sh"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -64,3 +64,14 @@ jobs:
       date: ${{ inputs.date }}
       package-name: rapids_logger
       package-type: cpp
+  static-build:
+    needs: style
+    secrets: inherit
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@branch-25.02
+    with:
+      build_type: ${{ inputs.build_type || 'branch' }}
+      branch: ${{ inputs.branch }}
+      sha: ${{ inputs.sha }}
+      date: ${{ inputs.date }}
+      container_image: "rapidsai/ci-wheel:latest"
+      run_script: "ci/configure_cpp_static.sh"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -39,3 +39,11 @@ jobs:
       build_type: pull-request
       matrix_filter: group_by(.ARCH) | map(max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]))
       script: ci/build_wheel.sh
+  static-build:
+    needs: style
+    secrets: inherit
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@branch-25.02
+    with:
+      build_type: pull-request
+      container_image: "rapidsai/ci-wheel:latest"
+      run_script: "ci/configure_cpp_static.sh"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -46,4 +46,4 @@ jobs:
     with:
       build_type: pull-request
       container_image: "rapidsai/ci-wheel:latest"
-      run_script: "ci/configure_cpp_static.sh"
+      run_script: "ci/build_static.sh"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,11 +39,12 @@ option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 include(CMakeDependentOption)
 # We cannot hide all spdlog symbols if we are building a static library.
 cmake_dependent_option(
-    RAPIDS_LOGGER_HIDE_ALL_SPDLOG_SYMBOLS "Build and link to spdlog in a way that maximizes all symbol hiding" ON
-    "BUILD_SHARED_LIBS" OFF
+  RAPIDS_LOGGER_HIDE_ALL_SPDLOG_SYMBOLS
+  "Build and link to spdlog in a way that maximizes all symbol hiding" ON "BUILD_SHARED_LIBS" OFF
 )
 
-# If we are hiding all spdlog symbols then we need to use the bundled fmt library, so this option is only configurable if we are not hiding those symbols.
+# If we are hiding all spdlog symbols then we need to use the bundled fmt library, so this option is
+# only configurable if we are not hiding those symbols.
 cmake_dependent_option(
   RAPIDS_LOGGER_FMT_OPTION "The fmt option to use when building spdlog." "EXTERNAL_FMT_HO"
   "NOT RAPIDS_LOGGER_HIDE_ALL_SPDLOG_SYMBOLS" "BUNDLED"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,15 +33,17 @@ rapids_cmake_build_type(Release)
 
 rapids_cpm_init()
 
-option(RAPIDS_LOGGER_HIDE_ALL_SPDLOG_SYMBOLS
-       "Build and link to spdlog in a way that maximizes all symbol hiding" ON
-)
 option(BUILD_TESTS "Configure CMake to build tests" ON)
 option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 
 include(CMakeDependentOption)
-# If we are hiding all spdlog symbols then we need to use the bundled fmt library, so this option
-# depends on what the above is set to.
+# We cannot hide all spdlog symbols if we are building a static library.
+cmake_dependent_option(
+    RAPIDS_LOGGER_HIDE_ALL_SPDLOG_SYMBOLS "Build and link to spdlog in a way that maximizes all symbol hiding" ON
+    "BUILD_SHARED_LIBS" OFF
+)
+
+# If we are hiding all spdlog symbols then we need to use the bundled fmt library, so this option is only configurable if we are not hiding those symbols.
 cmake_dependent_option(
   RAPIDS_LOGGER_FMT_OPTION "The fmt option to use when building spdlog." "EXTERNAL_FMT_HO"
   "NOT RAPIDS_LOGGER_HIDE_ALL_SPDLOG_SYMBOLS" "BUNDLED"

--- a/ci/build_static.sh
+++ b/ci/build_static.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Copyright (c) 2025, NVIDIA CORPORATION.
+
+set -euo pipefail
+
+source rapids-date-string
+
+rapids-logger "Static cpp build"
+
+cmake -S cpp -B build -DBUILD_SHARED_LIBS=OFF -DBUILD_TESTS=ON
+cmake --build build
+ctest --test-dir build --output-on-failure

--- a/ci/build_static.sh
+++ b/ci/build_static.sh
@@ -7,6 +7,6 @@ source rapids-date-string
 
 rapids-logger "Static cpp build"
 
-cmake -S cpp -B build -DBUILD_SHARED_LIBS=OFF -DBUILD_TESTS=ON
+cmake -S . -B build -DBUILD_SHARED_LIBS=OFF -DBUILD_TESTS=ON
 cmake --build build
 ctest --test-dir build --output-on-failure

--- a/python/rapids-logger/rapids_logger/__init__.py
+++ b/python/rapids-logger/rapids_logger/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from rapids_logger._version import __git_commit__, __version__
+from rapids_logger._version import __version__
 from rapids_logger.load import load_library
 
-__all__ = ["__git_commit__", "__version__", "load_library"]
+__all__ = ["__version__", "load_library"]

--- a/tests/template/cmake_test.cmake
+++ b/tests/template/cmake_test.cmake
@@ -48,7 +48,7 @@ function(add_cmake_test source_or_dir)
     endforeach()
   endif()
 
-  find_program(NINJA_EXECUTABLE ninja2)
+  find_program(NINJA_EXECUTABLE ninja)
   set(generator)
   if(NOT "${NINJA_EXECUTABLE}" STREQUAL "NINJA_EXECUTABLE-NOTFOUND")
     set(generator "-GNinja")

--- a/tests/template/cmake_test.cmake
+++ b/tests/template/cmake_test.cmake
@@ -60,8 +60,7 @@ function(add_cmake_test source_or_dir)
     COMMAND
       ${CMAKE_COMMAND} -S ${src_dir} -B ${build_dir}
       # This function assumes _version is set in the calling file.
-      -Drapids_logger_version=${_version}
-      ${generator} ${extra_args}
+      -Drapids_logger_version=${_version} ${generator} ${extra_args}
   )
 
   add_test(NAME ${test_name}_build COMMAND ${CMAKE_COMMAND} --build ${build_dir})

--- a/tests/template/cmake_test.cmake
+++ b/tests/template/cmake_test.cmake
@@ -48,6 +48,12 @@ function(add_cmake_test source_or_dir)
     endforeach()
   endif()
 
+  find_program(NINJA_EXECUTABLE ninja2)
+  set(generator)
+  if(NOT "${NINJA_EXECUTABLE}" STREQUAL "NINJA_EXECUTABLE-NOTFOUND")
+    set(generator "-GNinja")
+  endif()
+
   set(build_dir "${CMAKE_CURRENT_BINARY_DIR}/${test_name}-build")
   add_test(
     NAME ${test_name}_configure
@@ -55,9 +61,7 @@ function(add_cmake_test source_or_dir)
       ${CMAKE_COMMAND} -S ${src_dir} -B ${build_dir}
       # This function assumes _version is set in the calling file.
       -Drapids_logger_version=${_version}
-      # Hardcoding Ninja to simplify things. Assumes Ninja is available when running tests, which is
-      # not a very onerous requirement.
-      -G Ninja ${extra_args}
+      ${generator} ${extra_args}
   )
 
   add_test(NAME ${test_name}_build COMMAND ${CMAKE_COMMAND} --build ${build_dir})

--- a/tests/template/generate_logger_macros/CMakeLists.txt
+++ b/tests/template/generate_logger_macros/CMakeLists.txt
@@ -30,3 +30,4 @@ target_include_directories(
   generate_logger_macros PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>"
                                 "$<INSTALL_INTERFACE:include>"
 )
+set_target_properties(generate_logger_macros PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)


### PR DESCRIPTION
This helps ensure that consumers that build static libraries (like Spark) continue to work.

I also fixed a small issue in the Python packaging.