### PR TITLE
Add symbol checking in CI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,7 +84,7 @@ if(RAPIDS_LOGGER_HIDE_ALL_SPDLOG_SYMBOLS)
     FMT_OPTION ${RAPIDS_LOGGER_FMT_OPTION} CPM_ARGS OPTIONS "BUILD_SHARED_LIBS OFF"
                                            "SPDLOG_BUILD_SHARED OFF"
   )
-  set_target_properties(spdlog PROPERTIES CXX_VISIBILITY_PRESET hidden POSITION_INDEPENDENT_CODE ON)
+  set_target_properties(spdlog PROPERTIES POSITION_INDEPENDENT_CODE ON)
   target_link_options(rapids_logger PRIVATE "LINKER:--exclude-libs,libspdlog")
 else()
   rapids_cpm_spdlog(

--- a/ci/build_static.sh
+++ b/ci/build_static.sh
@@ -7,6 +7,10 @@ source rapids-date-string
 
 rapids-logger "Static cpp build"
 
+# Make sure we have an updated CMake
+python -m pip install -U cmake
+pyenv rehash
+
 cmake -S . -B build -DBUILD_SHARED_LIBS=OFF -DBUILD_TESTS=ON
 cmake --build build
 ctest --test-dir build --output-on-failure

--- a/ci/check_symbols.sh
+++ b/ci/check_symbols.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Copyright (c) 2025, NVIDIA CORPORATION.
+
+set -eEuo pipefail
+
+echo "checking for symbol visibility issues"
+
+LIBRARY="${1}"
+
+echo ""
+echo "Checking exported symbols in '${LIBRARY}'"
+symbol_file="./symbols.txt"
+readelf --dyn-syms --wide "${LIBRARY}" \
+    | c++filt \
+    > "${symbol_file}"
+
+for lib in fmt spdlog; do
+    echo "Checking for '${lib}' symbols..."
+    if grep -E "${lib}\:\:" "${symbol_file}"; then
+        echo "ERROR: Found some exported symbols in ${LIBRARY} matching the pattern ${lib}::."
+        exit 1
+    fi
+done
+
+echo "No symbol visibility issues found in ${LIBRARY}"

--- a/conda/recipes/rapids-logger/recipe.yaml
+++ b/conda/recipes/rapids-logger/recipe.yaml
@@ -18,7 +18,7 @@ build:
     # Run tests from the build directory since they're cheap.
     ctest --test-dir build/ --output-on-failure
     cmake --install build/
-    # Verify the symbols
+    # Check that no undefined symbols are present in the shared library
     LIB="build/librapids_logger.so"
     test -f build/librapids_logger.so
     ./ci/check_symbols.sh build/librapids_logger.so

--- a/conda/recipes/rapids-logger/recipe.yaml
+++ b/conda/recipes/rapids-logger/recipe.yaml
@@ -20,8 +20,8 @@ build:
     cmake --install build/
     # Check that no undefined symbols are present in the shared library
     LIB="build/librapids_logger.so"
-    test -f build/librapids_logger.so
-    ./ci/check_symbols.sh build/librapids_logger.so
+    test -f "${LIB}"
+    ./ci/check_symbols.sh "${LIB}"
 
 
 requirements:

--- a/conda/recipes/rapids-logger/recipe.yaml
+++ b/conda/recipes/rapids-logger/recipe.yaml
@@ -18,6 +18,11 @@ build:
     # Run tests from the build directory since they're cheap.
     ctest --test-dir build/ --output-on-failure
     cmake --install build/
+    # Verify the symbols
+    LIB="build/librapids_logger.so"
+    test -f build/librapids_logger.so
+    ./ci/check_symbols.sh build/librapids_logger.so
+
 
 requirements:
   build:


### PR DESCRIPTION
This PR adds verification that no spdlog or fmt symbols are part of the dynamic symbol table for the rapids_logger binaries.