### PR TITLE
updated wheel-name to package-name in CI workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,7 +53,7 @@ jobs:
       sha: ${{ inputs.sha }}
       matrix_filter: group_by(.ARCH) | map(max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]))
       script: ci/build_wheel.sh
-      wheel-name: rapids_logger
+      package-name: rapids_logger
       package-type: cpp
       append-cuda-suffix: false
   wheel-publish-cpp:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -39,7 +39,7 @@ jobs:
       build_type: pull-request
       matrix_filter: group_by(.ARCH) | map(max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]))
       script: ci/build_wheel.sh
-      wheel-name: rapids_logger
+      package-name: rapids_logger
       package-type: cpp
       append-cuda-suffix: false
   static-build:


### PR DESCRIPTION
This work is towards moving build artifacts from `downloads.rapids.ai` to Github Artifact Store (see https://github.com/rapidsai/ops/issues/2982)

Updates CI workflows to follow `package-name` convention between wheel build and wheel publish jobs.