### PR TITLE
Update to clang 20

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     hooks:
       - id: fix-smartquotes
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v16.0.6
+    rev: v20.1.4
     hooks:
       - id: clang-format
         types_or: [c, c++]


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/177

This PR updates the clang version to 20.
