### PR TITLE
Pin fmt for static configure job

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -15,11 +15,13 @@ files:
     output: none
     includes:
       - build_common
-      - spdlog_deps
+      - spdlog
+      - fmt
   test_static_library:
     output: none
     includes:
       - build_common
+      - fmt
 channels:
   - conda-forge
   - nodefaults
@@ -52,9 +54,13 @@ dependencies:
           - cmake>=3.30.4
           - ninja
           - cxx-compiler
-  spdlog_deps:
+  spdlog:
     common:
       - output_types: conda
         packages:
           - spdlog==1.14.1
+  fmt:
+    common:
+      - output_types: conda
+        packages:
           - fmt==11.0.2


### PR DESCRIPTION
The fmt version needs to be compatible with the spdlog version. Resolves the issues observed in #35 