### PR TITLE
WIP: use 'rapids-init-pip' in wheel CI, other CI change

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -76,7 +76,7 @@ jobs:
       sha: ${{ inputs.sha }}
       date: ${{ inputs.date }}
       container_image: "rapidsai/ci-conda:latest"
-      run_script: "ci/build_static.sh"
+      script: "ci/build_static.sh"
   dynamic-build:
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@branch-25.06
@@ -86,4 +86,4 @@ jobs:
       sha: ${{ inputs.sha }}
       date: ${{ inputs.date }}
       container_image: "rapidsai/ci-conda:latest"
-      run_script: "ci/build_dynamic.sh"
+      script: "ci/build_dynamic.sh"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -49,7 +49,7 @@ jobs:
     with:
       build_type: pull-request
       container_image: "rapidsai/ci-conda:latest"
-      run_script: "ci/build_static.sh"
+      script: "ci/build_static.sh"
   dynamic-build:
     needs: style
     secrets: inherit
@@ -57,4 +57,4 @@ jobs:
     with:
       build_type: pull-request
       container_image: "rapidsai/ci-conda:latest"
-      run_script: "ci/build_dynamic.sh"
+      script: "ci/build_dynamic.sh"

--- a/ci/build_conda.sh
+++ b/ci/build_conda.sh
@@ -3,8 +3,6 @@
 
 set -euo pipefail
 
-rapids-configure-conda-channels
-
 source rapids-configure-sccache
 
 export CMAKE_GENERATOR=Ninja

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -9,6 +9,7 @@ dist_dir="${package_dir}/dist"
 final_dir="${RAPIDS_WHEEL_BLD_OUTPUT_DIR}"
 
 source rapids-configure-sccache
+source rapids-init-pip
 
 rapids-generate-version > ./VERSION
 


### PR DESCRIPTION
## Description

Proposes a batch of small, mostly-unrelated changes to building and packaging.

These are all part of RAPIDS-wide efforts to make it easier to reproduce CI locally and to use artifacts from one project's CI in another project's CI.

Contributes to https://github.com/rapidsai/shared-workflows/issues/337

* switches from input `run_script` to `script` in uses of the `custom-job` workflow

Contributes to https://github.com/rapidsai/build-planning/issues/179

* adds a call to `rapids-init-pip` near the beginning of all CI scripts that use `pip`

Contributes to https://github.com/rapidsai/gha-tools/issues/145

* removes unnecessary call to `rapids-configure-conda-channels` in build scripts using `rattler-build`