### PR TITLE
Use std::format instead of fmtlib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,16 +40,15 @@ function(get_spdlog)
     set(to_install ON)
   endif()
 
-  set(version 1.14.1)
-  set(tag "v${version}")
+  set(spdlog_version 1.14.1)
 
   include("${rapids-cmake-dir}/cpm/find.cmake")
   rapids_cpm_find(
-    spdlog "${version}" ${_RAPIDS_UNPARSED_ARGUMENTS}
+    spdlog "${spdlog_version}" ${_RAPIDS_UNPARSED_ARGUMENTS}
     GLOBAL_TARGETS spdlog::spdlog spdlog::spdlog_header_only
     CPM_ARGS
     GIT_REPOSITORY https://github.com/gabime/spdlog.git
-    GIT_TAG "${tag}"
+    GIT_TAG "v${spdlog_version}"
     GIT_SHALLOW ON
     EXCLUDE_FROM_ALL ON
     OPTIONS "SPDLOG_INSTALL ${to_install}" "SPDLOG_USE_STD_FORMAT ON"
@@ -144,6 +143,7 @@ install(FILES ${CMAKE_CURRENT_LIST_DIR}/cmake/create_logger_macros.cmake
         DESTINATION "${lib_dir}/cmake/rapids_logger"
 )
 
+# cmake-lint: disable=E1126
 file(COPY_FILE "${CMAKE_CURRENT_LIST_DIR}/cmake/logger_macros.hpp.in"
      "${CMAKE_CURRENT_BINARY_DIR}/logger_macros.hpp.in"
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,7 +121,7 @@ function(get_spdlog)
     GIT_TAG "v${version}"
     GIT_SHALLOW ON
     EXCLUDE_FROM_ALL ON
-    OPTIONS "SPDLOG_INSTALL ${to_install}" "${spdlog_fmt_option}"
+    OPTIONS "SPDLOG_INSTALL ${to_install}" "SPDLOG_USE_STD_FORMAT ON"
   )
 
   # Propagate up variables that CPMFindPackage provide
@@ -191,7 +191,7 @@ set_target_properties(
   PROPERTIES BUILD_RPATH "\$ORIGIN"
              INSTALL_RPATH "\$ORIGIN"
              # set target compile options
-             CXX_STANDARD 17
+             CXX_STANDARD 20
              CXX_STANDARD_REQUIRED ON
              CXX_VISIBILITY_PRESET hidden
              POSITION_INDEPENDENT_CODE ON

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,14 +103,8 @@ if(RAPIDS_LOGGER_HIDE_ALL_SPDLOG_SYMBOLS)
   target_link_options(rapids_logger PRIVATE "LINKER:--exclude-libs,libspdlog")
 else()
   get_spdlog(
-    BUILD_EXPORT_SET
-    rapids-logger-exports
-    INSTALL_EXPORT_SET
-    rapids-logger-exports
-    CPM_ARGS
-    OPTIONS
-    "BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS}"
-    "SPDLOG_BUILD_SHARED ${BUILD_SHARED_LIBS}"
+    BUILD_EXPORT_SET rapids-logger-exports INSTALL_EXPORT_SET rapids-logger-exports CPM_ARGS
+    OPTIONS "BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS}" "SPDLOG_BUILD_SHARED ${BUILD_SHARED_LIBS}"
   )
   if(spdlog_ADDED)
     set_target_properties(spdlog PROPERTIES POSITION_INDEPENDENT_CODE ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,8 +80,6 @@ cmake_dependent_option(
   "Build and link to spdlog in a way that maximizes all symbol hiding" ON "BUILD_SHARED_LIBS" OFF
 )
 
-# TODO: For Spark-RAPIDS we will have to support building this as a static library. We may need some
-# additional testing to make sure that will work.
 add_library(rapids_logger src/logger.cpp)
 add_library(rapids_logger::rapids_logger ALIAS rapids_logger)
 target_include_directories(
@@ -92,7 +90,6 @@ set_target_properties(
   rapids_logger
   PROPERTIES BUILD_RPATH "\$ORIGIN"
              INSTALL_RPATH "\$ORIGIN"
-             # set target compile options
              CXX_STANDARD 20
              CXX_STANDARD_REQUIRED ON
              CXX_VISIBILITY_PRESET hidden
@@ -147,7 +144,6 @@ install(FILES ${CMAKE_CURRENT_LIST_DIR}/cmake/create_logger_macros.cmake
         DESTINATION "${lib_dir}/cmake/rapids_logger"
 )
 
-# cmake-lint: disable=E1126
 file(COPY_FILE "${CMAKE_CURRENT_LIST_DIR}/cmake/logger_macros.hpp.in"
      "${CMAKE_CURRENT_BINARY_DIR}/logger_macros.hpp.in"
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,49 +19,10 @@ include(rapids-cmake)
 include(rapids-cpm)
 include(rapids-export)
 
-# Fetch fmt
-function(get_fmt)
-  set(to_install OFF)
-  if(INSTALL_EXPORT_SET IN_LIST ARGN)
-    set(to_install ON)
-  endif()
-
-  include("${rapids-cmake-dir}/cpm/find.cmake")
-  set(version 11.0.2)
-  rapids_cpm_find(
-    fmt "${version}" ${ARGN}
-    GLOBAL_TARGETS fmt::fmt fmt::fmt-header-only
-    CPM_ARGS
-    GIT_REPOSITORY https://github.com/fmtlib/fmt.git
-    GIT_TAG "v${version}"
-    GIT_SHALLOW ON
-    EXCLUDE_FROM_ALL ON
-    OPTIONS "FMT_INSTALL ${to_install}" "CMAKE_POSITION_INDEPENDENT_CODE ON"
-  )
-
-  # Propagate up variables that CPMFindPackage provide
-  set(fmt_SOURCE_DIR
-      "${fmt_SOURCE_DIR}"
-      PARENT_SCOPE
-  )
-  set(fmt_BINARY_DIR
-      "${fmt_BINARY_DIR}"
-      PARENT_SCOPE
-  )
-  set(fmt_ADDED
-      "${fmt_ADDED}"
-      PARENT_SCOPE
-  )
-  set(fmt_VERSION
-      ${version}
-      PARENT_SCOPE
-  )
-endfunction()
-
 # Fetch spdlog
 function(get_spdlog)
   set(options)
-  set(one_value FMT_OPTION BUILD_EXPORT_SET INSTALL_EXPORT_SET)
+  set(one_value BUILD_EXPORT_SET INSTALL_EXPORT_SET)
   set(multi_value)
   cmake_parse_arguments(_RAPIDS "${options}" "${one_value}" "${multi_value}" ${ARGN})
 
@@ -79,72 +40,18 @@ function(get_spdlog)
     set(to_install ON)
   endif()
 
-  # If the option wasn't passed to the command, default to header only fmt
-  if(NOT _RAPIDS_FMT_OPTION)
-    set(_RAPIDS_FMT_OPTION "EXTERNAL_FMT_HO")
-  endif()
-
-  if(_RAPIDS_FMT_OPTION STREQUAL "BUNDLED")
-    set(spdlog_fmt_option "")
-  elseif(_RAPIDS_FMT_OPTION STREQUAL "EXTERNAL_FMT")
-    set(spdlog_fmt_option "SPDLOG_FMT_EXTERNAL ON")
-    set(spdlog_fmt_target fmt::fmt)
-  elseif(_RAPIDS_FMT_OPTION STREQUAL "EXTERNAL_FMT_HO")
-    set(spdlog_fmt_option "SPDLOG_FMT_EXTERNAL_HO ON")
-    set(spdlog_fmt_target fmt::fmt-header-only)
-  elseif(_RAPIDS_FMT_OPTION STREQUAL "STD_FORMAT")
-    set(spdlog_fmt_option "SPDLOG_USE_STD_FORMAT ON")
-  else()
-    message(
-      FATAL_ERROR
-        "Invalid option used for FMT_OPTION, got: ${_RAPIDS_FMT_OPTION}, expected one of: 'BUNDLED', 'EXTERNAL_FMT', 'EXTERNAL_FMT_HO', 'STD_FORMAT'"
-    )
-  endif()
-
-  if(_RAPIDS_FMT_OPTION STREQUAL "EXTERNAL_FMT" OR _RAPIDS_FMT_OPTION STREQUAL "EXTERNAL_FMT_HO")
-    include("${rapids-cmake-dir}/cpm/fmt.cmake")
-
-    # Using `spdlog_ROOT` needs to cause any internal find calls in `spdlog-config.cmake` to first
-    # search beside it before looking globally.
-    list(APPEND fmt_ROOT ${spdlog_ROOT})
-
-    get_fmt(${_RAPIDS_UNPARSED_ARGUMENTS})
-  endif()
+  set(version 1.14.1)
+  set(tag "v${version}")
 
   include("${rapids-cmake-dir}/cpm/find.cmake")
-  set(version 1.14.1)
-  rapids_cpm_find(
-    spdlog "${version}" ${_RAPIDS_UNPARSED_ARGUMENTS}
-    GLOBAL_TARGETS spdlog::spdlog spdlog::spdlog_header_only
-    CPM_ARGS
-    GIT_REPOSITORY https://github.com/gabime/spdlog.git
-    GIT_TAG "v${version}"
-    GIT_SHALLOW ON
-    EXCLUDE_FROM_ALL ON
-    OPTIONS "SPDLOG_INSTALL ${to_install}" "SPDLOG_USE_STD_FORMAT ON"
-  )
-
-  # Propagate up variables that CPMFindPackage provide
-  set(spdlog_SOURCE_DIR
-      "${spdlog_SOURCE_DIR}"
-      PARENT_SCOPE
-  )
-  set(spdlog_BINARY_DIR
-      "${spdlog_BINARY_DIR}"
-      PARENT_SCOPE
-  )
-  set(spdlog_ADDED
-      "${spdlog_ADDED}"
-      PARENT_SCOPE
-  )
-  set(spdlog_VERSION
-      ${version}
-      PARENT_SCOPE
-  )
-  set(spdlog_fmt_target
-      ${spdlog_fmt_target}
-      PARENT_SCOPE
-  )
+  rapids_cpm_find(spdlog "${version}" ${_RAPIDS_UNPARSED_ARGUMENTS}
+                  GLOBAL_TARGETS spdlog::spdlog spdlog::spdlog_header_only
+                  CPM_ARGS
+                  GIT_REPOSITORY https://github.com/gabime/spdlog.git
+                  GIT_TAG "${tag}"
+                  GIT_SHALLOW ON
+                  EXCLUDE_FROM_ALL ON
+                  OPTIONS "SPDLOG_INSTALL ${to_install}" "SPDLOG_USE_STD_FORMAT ON")
 endfunction()
 
 file(READ "${CMAKE_CURRENT_LIST_DIR}/VERSION" _version)
@@ -171,13 +78,6 @@ cmake_dependent_option(
   "Build and link to spdlog in a way that maximizes all symbol hiding" ON "BUILD_SHARED_LIBS" OFF
 )
 
-# If we are hiding all spdlog symbols then we need to use the bundled fmt library, so this option is
-# only configurable if we are not hiding those symbols.
-cmake_dependent_option(
-  RAPIDS_LOGGER_FMT_OPTION "The fmt option to use when building spdlog." "EXTERNAL_FMT_HO"
-  "NOT RAPIDS_LOGGER_HIDE_ALL_SPDLOG_SYMBOLS" "BUNDLED"
-)
-
 # TODO: For Spark-RAPIDS we will have to support building this as a static library. We may need some
 # additional testing to make sure that will work.
 add_library(rapids_logger src/logger.cpp)
@@ -201,15 +101,13 @@ set_target_properties(
 if(RAPIDS_LOGGER_HIDE_ALL_SPDLOG_SYMBOLS)
   set(CPM_DOWNLOAD_spdlog ON)
   get_spdlog(
-    FMT_OPTION ${RAPIDS_LOGGER_FMT_OPTION} CPM_ARGS OPTIONS "BUILD_SHARED_LIBS OFF"
+    CPM_ARGS OPTIONS "BUILD_SHARED_LIBS OFF"
     "SPDLOG_BUILD_SHARED OFF"
   )
   set_target_properties(spdlog PROPERTIES POSITION_INDEPENDENT_CODE ON)
   target_link_options(rapids_logger PRIVATE "LINKER:--exclude-libs,libspdlog")
 else()
   get_spdlog(
-    FMT_OPTION
-    ${RAPIDS_LOGGER_FMT_OPTION}
     BUILD_EXPORT_SET
     rapids-logger-exports
     INSTALL_EXPORT_SET

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ include(rapids-cmake)
 include(rapids-cpm)
 include(rapids-export)
 
-# Fetch spdlog
+# Get spdlog
 function(get_spdlog)
   set(options)
   set(one_value BUILD_EXPORT_SET INSTALL_EXPORT_SET)
@@ -44,14 +44,16 @@ function(get_spdlog)
   set(tag "v${version}")
 
   include("${rapids-cmake-dir}/cpm/find.cmake")
-  rapids_cpm_find(spdlog "${version}" ${_RAPIDS_UNPARSED_ARGUMENTS}
-                  GLOBAL_TARGETS spdlog::spdlog spdlog::spdlog_header_only
-                  CPM_ARGS
-                  GIT_REPOSITORY https://github.com/gabime/spdlog.git
-                  GIT_TAG "${tag}"
-                  GIT_SHALLOW ON
-                  EXCLUDE_FROM_ALL ON
-                  OPTIONS "SPDLOG_INSTALL ${to_install}" "SPDLOG_USE_STD_FORMAT ON")
+  rapids_cpm_find(
+    spdlog "${version}" ${_RAPIDS_UNPARSED_ARGUMENTS}
+    GLOBAL_TARGETS spdlog::spdlog spdlog::spdlog_header_only
+    CPM_ARGS
+    GIT_REPOSITORY https://github.com/gabime/spdlog.git
+    GIT_TAG "${tag}"
+    GIT_SHALLOW ON
+    EXCLUDE_FROM_ALL ON
+    OPTIONS "SPDLOG_INSTALL ${to_install}" "SPDLOG_USE_STD_FORMAT ON"
+  )
 endfunction()
 
 file(READ "${CMAKE_CURRENT_LIST_DIR}/VERSION" _version)
@@ -100,10 +102,7 @@ set_target_properties(
 # Get spdlog
 if(RAPIDS_LOGGER_HIDE_ALL_SPDLOG_SYMBOLS)
   set(CPM_DOWNLOAD_spdlog ON)
-  get_spdlog(
-    CPM_ARGS OPTIONS "BUILD_SHARED_LIBS OFF"
-    "SPDLOG_BUILD_SHARED OFF"
-  )
+  get_spdlog(CPM_ARGS OPTIONS "BUILD_SHARED_LIBS OFF" "SPDLOG_BUILD_SHARED OFF")
   set_target_properties(spdlog PROPERTIES POSITION_INDEPENDENT_CODE ON)
   target_link_options(rapids_logger PRIVATE "LINKER:--exclude-libs,libspdlog")
 else()

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -56,4 +56,4 @@ dependencies:
     common:
       - output_types: conda
         packages:
-          - spdlog==1.15.3
+          - spdlog==1.14.1

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -16,12 +16,10 @@ files:
     includes:
       - build_common
       - spdlog
-      - fmt
   test_static_library:
     output: none
     includes:
       - build_common
-      - fmt
 channels:
   - conda-forge
   - nodefaults
@@ -58,9 +56,4 @@ dependencies:
     common:
       - output_types: conda
         packages:
-          - spdlog==1.14.1
-  fmt:
-    common:
-      - output_types: conda
-        packages:
-          - fmt==11.0.2
+          - spdlog==1.15.3

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -164,7 +164,7 @@ class callback_sink : public spdlog::sinks::base_sink<Mutex> {
   {
     spdlog::memory_buf_t formatted;
     spdlog::sinks::base_sink<Mutex>::formatter_->format(msg, formatted);
-    std::string msg_string = fmt::to_string(formatted);
+    std::string msg_string = std::format("{}", formatted);
 
     if (_callback) {
       _callback(static_cast<int>(msg.level), msg_string.c_str());


### PR DESCRIPTION
This PR removes the need for fmt by using the std::format functionality added in C++20 (for which fmtlib was the reference implementation).