### PR TITLE
Fix fmt fetching

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,12 +102,6 @@ function(get_spdlog)
   endif()
 
   if(_RAPIDS_FMT_OPTION STREQUAL "EXTERNAL_FMT" OR _RAPIDS_FMT_OPTION STREQUAL "EXTERNAL_FMT_HO")
-    include("${rapids-cmake-dir}/cpm/fmt.cmake")
-
-    # Using `spdlog_ROOT` needs to cause any internal find calls in `spdlog-config.cmake` to first
-    # search beside it before looking globally.
-    list(APPEND fmt_ROOT ${spdlog_ROOT})
-
     get_fmt(${_RAPIDS_UNPARSED_ARGUMENTS})
   endif()
 


### PR DESCRIPTION
I had previously assumed we would be able to release the unconditional switch over to std::format along with the migration away from rapids-cmake's fmt and spdlog modules, so I didn't test this interaction very thoroughly. Now that we are making a 0.2.x line without that, we need to fix bugs in that interop.