### PR TITLE
Fix fmt tag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ function(get_fmt)
     GLOBAL_TARGETS fmt::fmt fmt::fmt-header-only
     CPM_ARGS
     GIT_REPOSITORY https://github.com/fmtlib/fmt.git
-    GIT_TAG "v${version}"
+    GIT_TAG "${version}"
     GIT_SHALLOW ON
     EXCLUDE_FROM_ALL ON
     OPTIONS "FMT_INSTALL ${to_install}" "CMAKE_POSITION_INDEPENDENT_CODE ON"


### PR DESCRIPTION
fmt doesn't include the "v" prefix in its tags.