### PR TITLE
Remove CMAKE_CXX_SCAN_FOR_MODULES workaround now that sccache is updated

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================
@@ -11,11 +11,6 @@ include(rapids_config.cmake)
 include(rapids-cmake)
 include(rapids-cpm)
 include(rapids-export)
-
-# For now, disable CMake's automatic module scanning for C++ files. There is an sccache bug in the
-# version RAPIDS uses in CI that causes it to handle the resulting -M* flags incorrectly with
-# gcc>=14. We can remove this once we upgrade to a newer sccache version.
-set(CMAKE_CXX_SCAN_FOR_MODULES OFF)
 
 # Get spdlog
 function(get_spdlog)


### PR DESCRIPTION
Now that sccache has been updated in CI to a version that correctly handles the `-M*` flags generated by CMake's C++ module scanning, we can remove the `set(CMAKE_CXX_SCAN_FOR_MODULES OFF)` workaround that was added to suppress this behavior.