### PR TITLE
Support Fully offline builds which use a system spdlog

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,16 +99,16 @@ set_target_properties(
 if(RAPIDS_LOGGER_HIDE_ALL_SPDLOG_SYMBOLS)
   set(CPM_DOWNLOAD_spdlog ON)
   get_spdlog(CPM_ARGS OPTIONS "BUILD_SHARED_LIBS OFF" "SPDLOG_BUILD_SHARED OFF")
-  set_target_properties(spdlog PROPERTIES POSITION_INDEPENDENT_CODE ON)
   target_link_options(rapids_logger PRIVATE "LINKER:--exclude-libs,libspdlog")
 else()
   get_spdlog(
     BUILD_EXPORT_SET rapids-logger-exports INSTALL_EXPORT_SET rapids-logger-exports CPM_ARGS
     OPTIONS "BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS}" "SPDLOG_BUILD_SHARED ${BUILD_SHARED_LIBS}"
   )
-  if(spdlog_ADDED)
-    set_target_properties(spdlog PROPERTIES POSITION_INDEPENDENT_CODE ON)
-  endif()
+endif()
+
+if(TARGET spdlog)
+  set_target_properties(spdlog PROPERTIES POSITION_INDEPENDENT_CODE ON)
 endif()
 target_link_libraries(rapids_logger PRIVATE spdlog::spdlog)
 


### PR DESCRIPTION
Found an issue when writing a fully offline build example for rapids-cmake ( https://github.com/rapidsai/rapids-cmake/pull/995 ). In those cases a system spdlog is still used even though `CPM_DOWNLOAD_spdlog` is enabled. 

So we check the existence of the `spdlog` target before setting any properties on it.