### PR TITLE
feat(wheels): publish wheel to PyPI automatically on release build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -84,6 +84,7 @@ jobs:
       sha: ${{ inputs.sha }}
       date: ${{ inputs.date }}
       package-name: rapids_logger
+      publish_to_pypi: true
       package-type: cpp
     permissions:
       actions: read


### PR DESCRIPTION
We want wheels to get published to PyPI when a new release is cut.

This is (unintentionally) obfuscated because of the nature of shared-workflows,
but by setting `publish_to_pypi: True`, we enter a new workflow block as part
of `wheels-publish.yaml` that checks for that publish boolean, and also if the
current build is a release build, as dictated by `gha-tools`
`rapids-is-release-build`.

`rapids-is-release-build` checks the `$GITHUB_REF` env-var populated by GitHub
Actions and returns a non-zero exit code if that variable matches
`^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$`.


TLDR: create a release, you should get a wheel.

