### PR TITLE
feat(conda): enable dual-publish of release artifacts to `rapidsai` and `rapidsai-nightly`

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -48,6 +48,7 @@ jobs:
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
       sha: ${{ inputs.sha }}
+      dual_publish: true
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
Does what it says on the tin -- for a release build (when a new tag/release is created), publish the artifacts to both the stable and nightly channels
